### PR TITLE
chore: promote jx3-msa-01 to version 0.0.1

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/jx3-msa-01
-  version: ersion=0.0.1
+  version: 0.0.1
   name: jx3-msa-01
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-msa-01 to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
